### PR TITLE
MaxLength annotation for fields in repositories

### DIFF
--- a/kuick-core/src/commonMain/kotlin/kuick/repositories/annotations/annotations.kt
+++ b/kuick-core/src/commonMain/kotlin/kuick/repositories/annotations/annotations.kt
@@ -1,0 +1,5 @@
+package kuick.repositories.annotations
+
+@Retention(AnnotationRetention.RUNTIME)
+@Target(AnnotationTarget.FIELD)
+annotation class MaxLength(val maxLength: Int)

--- a/kuick-repositories-elasticsearch/src/jvmMain/kotlin/kuick/repositories/elasticsearch/orm/schema.kt
+++ b/kuick-repositories-elasticsearch/src/jvmMain/kotlin/kuick/repositories/elasticsearch/orm/schema.kt
@@ -1,12 +1,12 @@
 package kuick.repositories.elasticsearch.orm
 
 
+import kuick.repositories.annotations.*
 import kuick.repositories.elasticsearch.orm.ElasticSearchFieldType.KEYWORD
 import kuick.utils.nonStaticFields
 import kotlin.reflect.KClass
 import kotlin.reflect.KProperty1
-import kotlin.reflect.full.declaredMemberProperties
-import kotlin.reflect.full.starProjectedType
+import kotlin.reflect.full.*
 
 class ElasticSearchIndexSchema<T : Any?> {
 
@@ -43,6 +43,7 @@ class ElasticSearchIndexSchema<T : Any?> {
                     }.filter {
                         this.get(it) == null
                     }.forEach { prop ->
+                        val maxLength = prop.findAnnotation<MaxLength>()?.maxLength
                         val nullableProp = prop.returnType.isMarkedNullable
                         val returnType = prop.returnType.classifier!!.starProjectedType
                         val columnName = prop.name

--- a/kuick-repositories-squash/src/jvmTest/kotlin/kuick/repositories/squash/SquashRepoTest.kt
+++ b/kuick-repositories-squash/src/jvmTest/kotlin/kuick/repositories/squash/SquashRepoTest.kt
@@ -20,11 +20,14 @@ class SquashRepoTest {
         db.runInTransaction {
             repo.insert(User("1234", "12"))
         }
-        assertFailsWith<JdbcSQLException> {
-            db.runInTransaction {
-                repo.insert(User("12345", "123"))
-            }
-        }
-        Unit
+        assertEquals(
+            "Value too long for column \"A VARCHAR(4) NOT NULL\": \"'12345' (5)\"; SQL statement:\n" +
+            "INSERT INTO \"User\" (a, b) VALUES (?, ?) [22001-197]",
+            assertFailsWith<JdbcSQLException> {
+                db.runInTransaction {
+                    repo.insert(User("12345", "123"))
+                }
+            }.message
+        )
     }
 }

--- a/kuick-repositories-squash/src/jvmTest/kotlin/kuick/repositories/squash/SquashRepoTest.kt
+++ b/kuick-repositories-squash/src/jvmTest/kotlin/kuick/repositories/squash/SquashRepoTest.kt
@@ -1,0 +1,30 @@
+package kuick.repositories.squash
+
+import kotlinx.coroutines.*
+import kuick.repositories.annotations.*
+import org.h2.jdbc.*
+import org.jetbrains.squash.dialects.h2.*
+import org.junit.Test
+import kotlin.test.*
+
+class SquashRepoTest {
+    data class User(@MaxLength(4) val a: String, @MaxLength(2) val b: String)
+
+    @Test
+    fun `maxLength is taken into account`(): Unit = runBlocking {
+        val db = H2Connection.createMemoryConnection()
+        val repo = ModelRepositorySquash(User::class, User::a)
+        db.runInTransaction {
+            repo.init()
+        }
+        db.runInTransaction {
+            repo.insert(User("1234", "12"))
+        }
+        assertFailsWith<JdbcSQLException> {
+            db.runInTransaction {
+                repo.insert(User("12345", "123"))
+            }
+        }
+        Unit
+    }
+}

--- a/kuick-repositories-squash/src/jvmTest/kotlin/kuick/repositories/squash/test-squash-repo.kt
+++ b/kuick-repositories-squash/src/jvmTest/kotlin/kuick/repositories/squash/test-squash-repo.kt
@@ -1,20 +1,16 @@
 package kuick.repositories.squash
 
-import kuick.db.DomainTransactionContext
-import kuick.models.Id
-import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.withContext
-import kuick.repositories.ModelQuery
-import kuick.repositories.eq
-import kuick.repositories.gt
-import kuick.repositories.gte
-import kuick.repositories.squash.orm.DomainTransactionSquash
-import org.jetbrains.squash.connection.DatabaseConnection
-import org.jetbrains.squash.connection.transaction
-import org.jetbrains.squash.dialects.h2.H2Connection
+import kotlinx.coroutines.*
+import kuick.db.*
+import kuick.models.*
+import kuick.repositories.*
+import kuick.repositories.annotations.*
+import kuick.repositories.squash.orm.*
+import org.jetbrains.squash.connection.*
+import org.jetbrains.squash.dialects.h2.*
+import org.junit.*
 
-
-data class UserId(override val id: String): Id
+data class UserId(override val id: String) : Id
 
 data class User(val userId: UserId,
                 val firstName: String,
@@ -24,7 +20,7 @@ data class User(val userId: UserId,
 )
 
 
-fun DatabaseConnection.runInTransaction(actions: suspend () -> Unit)  = transaction {
+fun DatabaseConnection.runInTransaction(actions: suspend () -> Unit) = transaction {
     val tr = DomainTransactionSquash(this)
     runBlocking {
         withContext(DomainTransactionContext(tr)) {


### PR DESCRIPTION
Can be used in conjunction with #5 to provide maxlength defauls per table, but also being able to fine-tune per column/field.

I have also added a test.