### PR TITLE
Cached repository implementation

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=0.0.9
+version=0.0.10
 kotlinx_coroutines_version=1.1.1
 squash_version=0.2.6-new-coroutines
 ktor_version=1.1.3

--- a/kuick-core/src/commonMain/kotlin/kuick/caching/Cache.kt
+++ b/kuick-core/src/commonMain/kotlin/kuick/caching/Cache.kt
@@ -1,0 +1,7 @@
+package kuick.caching
+
+
+interface Cache<K: Any, T:Any> {
+    suspend fun get(key: K, builder: suspend () -> T?): T
+    suspend fun invalidate(key: K)
+}

--- a/kuick-core/src/commonMain/kotlin/kuick/caching/CachedRepository.kt
+++ b/kuick-core/src/commonMain/kotlin/kuick/caching/CachedRepository.kt
@@ -1,4 +1,74 @@
 package kuick.caching
 
-class CachedRepository {
+import kuick.repositories.FieldEqs
+import kuick.repositories.FilterExpAnd
+import kuick.repositories.ModelQuery
+import kuick.repositories.ModelRepository
+import kuick.repositories.memory.ModelRepositoryMemory
+import kuick.repositories.patterns.ModelRepositoryDecorator
+import kotlin.reflect.KClass
+import kotlin.reflect.KProperty1
+
+open class CachedRepository<I: Any, T: Any, C:Any>(
+        val modelClass: KClass<T>,
+        val idField: KProperty1<T, I>,
+        val repo: ModelRepository<I, T>,
+        private val cache: Cache<C, List<T>>,
+        private val cacheField: KProperty1<T, C>
+): ModelRepositoryDecorator<I, T>(repo) {
+
+    private suspend fun invalidate(t: T) = invalidateKey(cacheField(t))
+
+    private suspend fun invalidateKey(key: C) {
+        cache.invalidate(key)
+    }
+
+    override suspend fun insert(t: T): T {
+        invalidate(t)
+        return super.insert(t)
+    }
+
+    override suspend fun update(t: T): T {
+        invalidate(t)
+        return super.update(t)
+    }
+
+    override suspend fun delete(i: I) {
+        val t = findById(i) ?: throw IllegalArgumentException()
+        super.delete(i)
+        invalidate(t)
+    }
+
+    override suspend fun deleteBy(q: ModelQuery<T>) {
+        val keyEq = findCacheQuery(q)
+        if (keyEq != null) {
+            val key = keyEq.value as C
+            invalidateKey(key)
+        } else {
+            findBy(q).map { cacheField(it) }.distinct().forEach { invalidateKey(it) }
+        }
+        super.deleteBy(q)
+    }
+
+    override suspend fun findBy(q: ModelQuery<T>): List<T> {
+        val keyEq = findCacheQuery(q)
+        return if (keyEq != null) {
+            val key = keyEq.value as C
+            val subset = cache.get(key) {
+                super.findBy(FieldEqs(cacheField, key))
+            }
+            val subRepo = ModelRepositoryMemory(modelClass, idField)
+            subset.forEach { subRepo.insert(it) }
+            subRepo.findBy(q)
+        } else {
+            super.findBy(q)
+        }
+    }
+
+    private fun findCacheQuery(q: ModelQuery<T>): FieldEqs<T, *>? = when {
+        q is FieldEqs<T, *> && q.field == cacheField-> q
+        q is FilterExpAnd<T> -> findCacheQuery(q.left) ?: findCacheQuery(q.right)
+        else -> null
+    }
+
 }

--- a/kuick-core/src/jvmMain/kotlin/kuick/caching/GoogleMemoryCache.kt
+++ b/kuick-core/src/jvmMain/kotlin/kuick/caching/GoogleMemoryCache.kt
@@ -1,0 +1,32 @@
+package kuick.caching
+
+import com.google.common.cache.CacheBuilder
+import kotlinx.coroutines.runBlocking
+import kuick.core.KuickInternal
+import kuick.di.injector
+import kuick.di.withInjectorContext
+import java.time.Duration
+import java.util.concurrent.TimeUnit
+
+class GoogleMemoryCache<K: Any, T:Any>(maxSize: Long, duration: Duration) : Cache<K, T> {
+
+    private val cache = CacheBuilder.newBuilder()
+            .maximumSize(maxSize)
+            .expireAfterWrite(duration.seconds, TimeUnit.SECONDS)
+            .build<String, T>()
+
+    @UseExperimental(KuickInternal::class)
+    override suspend fun get(key: K, builder: suspend () -> T?): T {
+        val injector = injector()
+        return cache.get(key.toString()) {
+            runBlocking {
+                withInjectorContext(injector) {
+                    builder()
+                }
+            }
+        }
+    }
+
+    override suspend fun invalidate(key: K) = cache.invalidate(key.toString())
+
+}


### PR DESCRIPTION
This `ModelRepository` implementation allows to decorate an existent repository with a cache based on one model's field. This allow to partition a repository by any field, cache each partition, and perform sub-partition queries in memory.