### PR TITLE
New date store format

### DIFF
--- a/kuick-repositories-squash/src/jvmMain/kotlin/kuick/repositories/squash/ModelRepositorySquash.kt
+++ b/kuick-repositories-squash/src/jvmMain/kotlin/kuick/repositories/squash/ModelRepositorySquash.kt
@@ -43,7 +43,7 @@ open class ModelRepositorySquash<I : Any, T : Any>(
                     returnType == Long::class.starProjectedType -> long(columnName)
                     returnType == Double::class.starProjectedType -> decimal(columnName, 5, 4)
                     returnType == Boolean::class.starProjectedType -> bool(columnName)
-                    returnType == Date::class.starProjectedType -> long(columnName)
+                    returnType == Date::class.starProjectedType -> varchar(columnName, LOCAL_DATE_TIME_LEN)
                     returnType == LocalDate::class.starProjectedType -> varchar(columnName, LOCAL_DATE_TIME_LEN)
                     returnType.isSubtypeOf(Id::class.starProjectedType) -> (varchar(columnName, ID_LEN))
                     else -> varchar(columnName, defaultMaxLength)

--- a/kuick-repositories-squash/src/jvmMain/kotlin/kuick/repositories/squash/ModelRepositorySquash.kt
+++ b/kuick-repositories-squash/src/jvmMain/kotlin/kuick/repositories/squash/ModelRepositorySquash.kt
@@ -43,7 +43,7 @@ open class ModelRepositorySquash<I : Any, T : Any>(
                     returnType == Long::class.starProjectedType -> long(columnName)
                     returnType == Double::class.starProjectedType -> decimal(columnName, 5, 4)
                     returnType == Boolean::class.starProjectedType -> bool(columnName)
-                    returnType == Date::class.starProjectedType -> varchar(columnName, LOCAL_DATE_TIME_LEN)
+                    returnType == Date::class.starProjectedType -> datetime(columnName)
                     returnType == LocalDate::class.starProjectedType -> varchar(columnName, LOCAL_DATE_TIME_LEN)
                     returnType.isSubtypeOf(Id::class.starProjectedType) -> (varchar(columnName, ID_LEN))
                     else -> varchar(columnName, defaultMaxLength)

--- a/kuick-repositories-squash/src/jvmMain/kotlin/kuick/repositories/squash/orm/squash-orm.kt
+++ b/kuick-repositories-squash/src/jvmMain/kotlin/kuick/repositories/squash/orm/squash-orm.kt
@@ -2,9 +2,9 @@ package kuick.repositories.squash.orm
 
 import kuick.db.DomainTransaction
 import kuick.json.Json
-import kuick.models.Email
 import kuick.models.Id
-import kuick.models.KLocalDate
+import kuick.repositories.squash.SerializationStrategy
+import kuick.repositories.squash.type
 import kuick.utils.nonStaticFields
 import org.jetbrains.squash.connection.*
 import org.jetbrains.squash.definition.ColumnDefinition
@@ -18,16 +18,14 @@ import org.jetbrains.squash.results.*
 import org.jetbrains.squash.statements.*
 import java.io.*
 import java.lang.reflect.Field
-import java.math.BigDecimal
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
-import java.util.*
 import java.util.concurrent.atomic.*
 import kotlin.reflect.KClass
 import kotlin.reflect.KProperty1
 import kotlin.reflect.full.*
-import java.time.ZoneOffset
+import kotlin.reflect.KType
 
 
 const val LOCAL_DATE_LEN = 16
@@ -36,6 +34,9 @@ const val ID_LEN = 36
 const val SHORT_TEXT_LEN = 512
 const val LONG_TEXT_LEN = 4000
 const val VERY_LONG_TEXT_LEN = 25000
+
+val DATE_FORMAT = DateTimeFormatter.ISO_DATE
+val DATE_TIME_FORMAT = DateTimeFormatter.ISO_DATE_TIME
 
 
 
@@ -56,88 +57,7 @@ class DomainTransactionSquash(val db: DatabaseConnection): DomainTransaction, Cl
     }
 }
 
-infix fun <T:Any> ResultRow.toDAO(ormDef: ORMTableDefinition<T>): T {
-    val fields = ormDef.clazz.toDAOFields()
-    val fieldValues = fields.map { f ->
-        try {
-            val property = ormDef.clazz.memberProperties.first { it.name == f.name }
-            val columnDef = ormDef.get(property)
-            readColumnValue(ormDef.clazz, f, columnDef.name.id, ormDef.compoundName.id)
-        } catch (t: Throwable) {
-            throw IllegalStateException("Had a problem reading field ${f}", t)
-        }
-    }
-    return ormDef.clazz.constructors.first().call(*fieldValues.toTypedArray())
-}
-
-private fun <T:Any> KClass<T>.toDAOFields() = java.nonStaticFields()
-
-private inline fun <reified T> ResultRow.columnValue(columnName: String, tableName: String?  = null): T? =
-        columnValue(T::class, columnName, tableName) as? T?
-
-private inline fun <T> ignoreErrors(callback: () -> T): T? = runCatching { callback() }.getOrNull()
-
-private fun <T:Any> ResultRow.readColumnValue(clazz: KClass<T>, field: Field, columnName: String, tableName: String): Any? = when (val type = field.type.kotlin) {
-    String::class, Boolean::class, Int::class, Long::class, Float::class -> columnValue(type, columnName, tableName)
-    Double::class, BigDecimal::class -> columnValue<BigDecimal>(columnName, tableName)?.toDouble()
-    Email::class -> columnValue<String>(columnName, tableName)?.let { Email(it) }
-    Date::class -> columnValue<LocalDateTime>(columnName, tableName)?.let {
-        val zoneOffset = ZoneOffset.UTC.normalized().rules.getOffset(it)
-        Date.from(it.toInstant(zoneOffset))
-        }
-
-    LocalDateTime::class -> columnValue<String>(columnName, tableName)?.let { LocalDateTime.parse(it, DATE_TIME_FORMAT) }
-    LocalDate::class -> columnValue<String>(columnName, tableName)?.takeIf { it != "0000-00-00" }?.let { dateAsStr ->
-        ignoreErrors { LocalDate.parse(dateAsStr, DATE_FORMAT) }
-            ?: ignoreErrors { LocalDate.parse(Json.fromJson<KLocalDate>(dateAsStr).toString(), DATE_FORMAT) }
-            ?: error("Unknown date format [$dateAsStr]")
-    }
-    else -> when {
-        type.isSubclassOf(Id::class) -> columnValue<String>(columnName, tableName)?.let { type.primaryConstructor?.call(it) }
-        else -> columnValue<String>(columnName, tableName)?.let { field.apply { isAccessible = true }.get(Json.fromJson("{\"${field.name}\":$it}", clazz)) }
-    }
-}
-
-
-infix fun <D:Any, T : Table> InsertValuesStatement<T, Unit>.from(data: D) {
-    val clazz = data::class.java
-    clazz.nonStaticFields().withIndex().forEach { (i, f) ->
-        f.isAccessible = true
-        val value = f.get(data)
-        val decodedValue = decodeValue(value)
-        if (i >= table.compoundColumns.size) throw NotImplementedError("Missing SQUASH column definition in ${table.javaClass.simpleName} for field ${f}")
-        val column = table.compoundColumns[i]
-        set(column, decodedValue)
-    }
-}
-infix fun <D:Any, T : Table> UpdateQueryStatement<T>.from(data: D) {
-    val clazz = data::class.java
-    clazz.nonStaticFields().withIndex().forEach { (i, f) ->
-        f.isAccessible = true
-        val value = f.get(data)
-        val decodedValue = decodeValue(value)
-        val column = table.compoundColumns[i]
-        set(column, decodedValue)
-    }
-}
-
-private val DATE_FORMAT = DateTimeFormatter.ISO_DATE
-private val DATE_TIME_FORMAT = DateTimeFormatter.ISO_DATE_TIME
-
-private fun decodeValue(value: Any?) = when (value) {
-    null -> null
-    is Id -> value.id
-    is Email -> value.email
-    is String, is Int, is Long, is Double -> value
-    is Date ->  LocalDateTime.ofInstant(value.toInstant(),ZoneOffset.UTC.normalized())
-    is LocalDate -> DATE_FORMAT.format(value)
-    is LocalDateTime -> DATE_TIME_FORMAT.format(value)
-    value::class.java == Int::class.java -> value
-    is Boolean -> value.toString().toBoolean()
-    else -> Json.toJson(value)
-}
-
-open class ORMTableDefinition<T : Any> (val clazz: KClass<T>, val tableName: String = clazz.simpleName!!): TableDefinition(tableName) {
+open class ORMTableDefinition<T : Any> (val serializationStrategies : Map<KType, SerializationStrategy<*>>, val clazz: KClass<T>, val tableName: String = clazz.simpleName!!): TableDefinition(tableName) {
     private val _map: MutableMap<KProperty1<T, *>, ColumnDefinition<*>> = mutableMapOf()
 
     infix fun <R: Any?> KProperty1<T, R>.to(cd: ColumnDefinition<R>) {
@@ -249,7 +169,69 @@ open class ORMTableDefinition<T : Any> (val clazz: KClass<T>, val tableName: Str
 
     private fun <R:Any> Statement<R>.monitorAndExecuteOn(tr: Transaction) =   executeOn(tr)
 
+    //=================================
+    infix fun <T:Any> ResultRow.toDAO(ormDef: ORMTableDefinition<T>): T {
+        val fields = ormDef.clazz.toDAOFields()
+        val fieldValues = fields.map { f ->
+            try {
+                val property = ormDef.clazz.memberProperties.first { it.name == f.name }
+                val columnDef = ormDef.get(property)
+                readColumnValue(ormDef.clazz, f, columnDef.name.id, ormDef.compoundName.id)
+            } catch (t: Throwable) {
+                throw IllegalStateException("Had a problem reading field ${f}", t)
+            }
+        }
+        return ormDef.clazz.constructors.first().call(*fieldValues.toTypedArray())
+    }
+
+    private fun <T:Any> ResultRow.readColumnValue(clazz: KClass<T>, field: Field, columnName: String, tableName: String): Any? = when  {
+        serializationStrategies.containsKey(field.type.kotlin.starProjectedType) -> serializationStrategies[field.type.kotlin.starProjectedType]!!.readColumnValue.invoke(field,this,columnName,tableName)
+        else -> when {
+            field.type.kotlin.isSubclassOf(Id::class) ->serializationStrategies[type<Id>()]!!.readColumnValue.invoke(field,this,columnName,tableName)
+            else -> columnValue<String>(columnName, tableName)?.let { field.apply { isAccessible = true }.get(Json.fromJson("{\"${field.name}\":$it}", clazz)) }
+        }
+    }
+
+
+    infix fun <D:Any, T : Table> InsertValuesStatement<T, Unit>.from(data: D) {
+        val clazz = data::class.java
+        clazz.nonStaticFields().withIndex().forEach { (i, f) ->
+            f.isAccessible = true
+            val value = f.get(data)
+            val decodedValue = decodeValue(value)
+            if (i >= table.compoundColumns.size) throw NotImplementedError("Missing SQUASH column definition in ${table.javaClass.simpleName} for field ${f}")
+            val column = table.compoundColumns[i]
+            set(column, decodedValue)
+        }
+    }
+    infix fun <D:Any, T : Table> UpdateQueryStatement<T>.from(data: D) {
+        val clazz = data::class.java
+        clazz.nonStaticFields().withIndex().forEach { (i, f) ->
+            f.isAccessible = true
+            val value = f.get(data)
+            val decodedValue = decodeValue(value)
+            val column = table.compoundColumns[i]
+            set(column, decodedValue)
+        }
+    }
+
+    private fun decodeValue(value: Any?) = when {
+        value == null -> null
+        serializationStrategies.containsKey(value::class.starProjectedType) -> serializationStrategies[value::class.starProjectedType]!!.decodeValue.invoke(value)
+        value is Id -> serializationStrategies[type<Id>()]!!.decodeValue.invoke(value)
+        else -> Json.toJson(value)
+    }
+
+    //=================================
+
 }
+
+private fun <T:Any> KClass<T>.toDAOFields() = java.nonStaticFields()
+
+inline fun <reified T> ResultRow.columnValue(columnName: String, tableName: String?  = null): T? =
+        columnValue(T::class, columnName, tableName) as? T?
+
+inline fun <T> ignoreErrors(callback: () -> T): T? = runCatching { callback() }.getOrNull()
 
 fun DomainTransaction.squashTr() = (this as LazyDomainTransactionSquash).tr
 

--- a/kuick-repositories-squash/src/jvmMain/kotlin/kuick/repositories/squash/orm/squash-orm.kt
+++ b/kuick-repositories-squash/src/jvmMain/kotlin/kuick/repositories/squash/orm/squash-orm.kt
@@ -81,10 +81,9 @@ private fun <T:Any> ResultRow.readColumnValue(clazz: KClass<T>, field: Field, co
     String::class, Boolean::class, Int::class, Long::class, Float::class -> columnValue(type, columnName, tableName)
     Double::class, BigDecimal::class -> columnValue<BigDecimal>(columnName, tableName)?.toDouble()
     Email::class -> columnValue<String>(columnName, tableName)?.let { Email(it) }
-    Date::class -> columnValue<String>(columnName, tableName)?.let {
-        val localDateTime = LocalDateTime.parse(it, DATE_TIME_FORMAT)
-        val zoneOffset = ZoneOffset.UTC.normalized().rules.getOffset(localDateTime)
-        Date.from(localDateTime.toInstant(zoneOffset))
+    Date::class -> columnValue<LocalDateTime>(columnName, tableName)?.let {
+        val zoneOffset = ZoneOffset.UTC.normalized().rules.getOffset(it)
+        Date.from(it.toInstant(zoneOffset))
         }
 
     LocalDateTime::class -> columnValue<String>(columnName, tableName)?.let { LocalDateTime.parse(it, DATE_TIME_FORMAT) }
@@ -130,7 +129,7 @@ private fun decodeValue(value: Any?) = when (value) {
     is Id -> value.id
     is Email -> value.email
     is String, is Int, is Long, is Double -> value
-    is Date ->   DATE_TIME_FORMAT.format(LocalDateTime.ofInstant(value.toInstant(),ZoneOffset.UTC.normalized()))
+    is Date ->  LocalDateTime.ofInstant(value.toInstant(),ZoneOffset.UTC.normalized())
     is LocalDate -> DATE_FORMAT.format(value)
     is LocalDateTime -> DATE_TIME_FORMAT.format(value)
     value::class.java == Int::class.java -> value

--- a/kuick-repositories-squash/src/jvmMain/kotlin/kuick/repositories/squash/serializationstrategies.kt
+++ b/kuick-repositories-squash/src/jvmMain/kotlin/kuick/repositories/squash/serializationstrategies.kt
@@ -1,42 +1,130 @@
 package kuick.repositories.squash
 
-import kuick.repositories.squash.orm.columnValue
-import org.jetbrains.squash.definition.ColumnDefinition
-import org.jetbrains.squash.definition.TableDefinition
-import org.jetbrains.squash.definition.datetime
-import org.jetbrains.squash.definition.long
+import kuick.json.Json
+import kuick.models.Email
+import kuick.models.Id
+import kuick.models.KLocalDate
+import kuick.repositories.squash.orm.*
+import org.jetbrains.squash.definition.*
 import org.jetbrains.squash.results.ResultRow
+import java.lang.reflect.Field
+import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.ZoneOffset
 import java.util.*
+import kotlin.reflect.KClass
+import kotlin.reflect.KType
+import kotlin.reflect.full.primaryConstructor
+import kotlin.reflect.full.starProjectedType
 
-interface DateSerializationStrategy {
 
-    fun getColumnDefinition(table: TableDefinition, columnName: String) : ColumnDefinition<Any?>
-    fun readColumnValue(result: ResultRow, columnName: String, tableName: String): Date?
-    fun decodeValue(value: Date) : Any?
+open class SerializationStrategy<T : Any>(
+        val getColumnDefinition: (table: TableDefinition, columnName: String) -> ColumnDefinition<Any?>,
+        val readColumnValue: (field: Field, resultRow: ResultRow, columnName: String, tableName: String) -> T?,
+        val decodeValue: (value: Any) -> Any?)
+
+class VarCharSerializationStrategy<T : Any>(
+        varcharLength: Int,
+        readColumnValue: (Field, ResultRow, String, String) -> T?,
+        decodeValue: (Any) -> Any?
+) : SerializationStrategy<T>({ table, columnName -> table.varchar(columnName, varcharLength) }, readColumnValue, decodeValue) {
+    fun withLength(length: Int) = VarCharSerializationStrategy(length, readColumnValue, decodeValue)
 }
 
-object dateSerializationAsDateTime : DateSerializationStrategy {
-    override fun getColumnDefinition(table: TableDefinition, columnName: String) : ColumnDefinition<Any?> =
-            table.datetime(columnName)
 
-    override fun readColumnValue(result: ResultRow, columnName: String, tableName: String): Date? =
+val dateSerializationAsDateTime = SerializationStrategy<Date>(
+        { table, columnName -> table.datetime(columnName) },
+        { type, result, columnName, tableName ->
             result.columnValue<LocalDateTime>(columnName, tableName)?.let {
                 val zoneOffset = ZoneOffset.UTC.normalized().rules.getOffset(it)
                 Date.from(it.toInstant(zoneOffset))
             }
+        },
+        { value -> LocalDateTime.ofInstant((value as Date).toInstant(), ZoneOffset.UTC.normalized()) })
 
-    override fun decodeValue(value: Date): Any? =
-            LocalDateTime.ofInstant(value.toInstant(), ZoneOffset.UTC.normalized())
+
+val dateSerializationAsLong = SerializationStrategy<Date>(
+        { table, columnName -> table.long(columnName) },
+        { field, result, columnName, tableName -> result.columnValue<Long>(columnName, tableName)?.let { Date(it) } },
+        { value -> (value as Date).time })
+
+
+val stringSerialization = VarCharSerializationStrategy(
+        LONG_TEXT_LEN,
+        { field, result, columnName, tableName -> result.columnValue<String>(columnName, tableName) },
+        { value -> value })
+
+val intSerialization = SerializationStrategy(
+        { table, columnName -> table.integer(columnName) },
+        { field, result, columnName, tableName -> result.columnValue<Int>(columnName, tableName) },
+        { value -> value })
+
+val longSerialization = SerializationStrategy(
+        { table, columnName -> table.long(columnName) },
+        { type, result, columnName, tableName -> result.columnValue<Long>(columnName, tableName) },
+        { value -> value })
+
+val doubleSerialization = SerializationStrategy(
+        { table, columnName -> table.decimal(columnName, 5, 4) },
+        { field, result, columnName, tableName -> result.columnValue<Double>(columnName, tableName) },
+        { value -> value })
+
+val booleanSerialization = SerializationStrategy(
+        { table, columnName -> table.bool(columnName) },
+        { field, result, columnName, tableName -> result.columnValue<Boolean>(columnName, tableName) },
+        { value -> value })
+
+val localDateSerialization = VarCharSerializationStrategy(
+        LOCAL_DATE_TIME_LEN,
+        { field, result, columnName, tableName ->
+            result.columnValue<String>(columnName, tableName)?.takeIf { it != "0000-00-00" }?.let { dateAsStr ->
+                ignoreErrors { LocalDate.parse(dateAsStr, DATE_FORMAT) }
+                        ?: ignoreErrors { LocalDate.parse(Json.fromJson<LocalDate>(dateAsStr).toString(), DATE_FORMAT) }
+                        ?: error("Unknown date format [$dateAsStr]")
+            }
+        },
+        { value -> DATE_FORMAT.format((value as LocalDate)) })
+
+
+val localDateTimeSerialization = VarCharSerializationStrategy(
+        LOCAL_DATE_TIME_LEN,
+        { field, result, columnName, tableName ->
+            result.columnValue<String>(columnName, tableName)?.let { LocalDateTime.parse(it, DATE_TIME_FORMAT) }
+        },
+        { value -> DATE_TIME_FORMAT.format(value as LocalDateTime) })
+
+val idSerialization = VarCharSerializationStrategy(
+        ID_LEN,
+        { field, result, columnName, tableName -> result.columnValue<String>(columnName, tableName)?.let { field.type.kotlin.primaryConstructor?.call(it) as Id? } },
+        { value -> (value as Id).id })
+
+
+val emailSerialization = VarCharSerializationStrategy(
+        LONG_TEXT_LEN,
+        { field, result, columnName, tableName -> result.columnValue<String>(columnName, tableName)?.let { Email(it) }},
+        { value -> (value as Email).email })
+
+
+class SerializationStrategies(val strategies: Map<KType, SerializationStrategy<out Any>> ){
+
+    fun withSerialization(clazz: KClass<*>,serialization: SerializationStrategy<out Any>) : SerializationStrategies{
+        val newMap = strategies.toMutableMap()
+        newMap[clazz.starProjectedType] = serialization
+        return SerializationStrategies(newMap)
+    }
 }
 
-object dateSerializationAsLong : DateSerializationStrategy {
-    override fun getColumnDefinition(table: TableDefinition, columnName: String) : ColumnDefinition<Any?> =
-            table.long(columnName)
+inline fun <reified T> type() : KType = T::class.starProjectedType
 
-    override fun readColumnValue(result: ResultRow, columnName: String, tableName: String): Date? =
-            result.columnValue<Long>(columnName, tableName)?.let { Date(it) }
+val defaultSerializationStrategies  = SerializationStrategies(mapOf(
+        Pair(type<Int>(),intSerialization),
+        Pair(type<Long>(), longSerialization),
+        Pair(type<String>(), stringSerialization),
+        Pair(type<Date>(), dateSerializationAsLong),
+        Pair(type<Double>(), doubleSerialization),
+        Pair(type<Boolean>(), booleanSerialization),
+        Pair(type<LocalDate>(), localDateSerialization),
+        Pair(type<LocalDateTime>(), localDateTimeSerialization),
+        Pair(type<Id>(), idSerialization),
+        Pair(type<Email>(), emailSerialization)))
 
-    override fun decodeValue(value: Date): Any? = value.time
-}

--- a/kuick-repositories-squash/src/jvmMain/kotlin/kuick/repositories/squash/serializationstrategies.kt
+++ b/kuick-repositories-squash/src/jvmMain/kotlin/kuick/repositories/squash/serializationstrategies.kt
@@ -1,0 +1,42 @@
+package kuick.repositories.squash
+
+import kuick.repositories.squash.orm.columnValue
+import org.jetbrains.squash.definition.ColumnDefinition
+import org.jetbrains.squash.definition.TableDefinition
+import org.jetbrains.squash.definition.datetime
+import org.jetbrains.squash.definition.long
+import org.jetbrains.squash.results.ResultRow
+import java.time.LocalDateTime
+import java.time.ZoneOffset
+import java.util.*
+
+interface DateSerializationStrategy {
+
+    fun getColumnDefinition(table: TableDefinition, columnName: String) : ColumnDefinition<Any?>
+    fun readColumnValue(result: ResultRow, columnName: String, tableName: String): Date?
+    fun decodeValue(value: Date) : Any?
+}
+
+object dateSerializationAsDateTime : DateSerializationStrategy {
+    override fun getColumnDefinition(table: TableDefinition, columnName: String) : ColumnDefinition<Any?> =
+            table.datetime(columnName)
+
+    override fun readColumnValue(result: ResultRow, columnName: String, tableName: String): Date? =
+            result.columnValue<LocalDateTime>(columnName, tableName)?.let {
+                val zoneOffset = ZoneOffset.UTC.normalized().rules.getOffset(it)
+                Date.from(it.toInstant(zoneOffset))
+            }
+
+    override fun decodeValue(value: Date): Any? =
+            LocalDateTime.ofInstant(value.toInstant(), ZoneOffset.UTC.normalized())
+}
+
+object dateSerializationAsLong : DateSerializationStrategy {
+    override fun getColumnDefinition(table: TableDefinition, columnName: String) : ColumnDefinition<Any?> =
+            table.long(columnName)
+
+    override fun readColumnValue(result: ResultRow, columnName: String, tableName: String): Date? =
+            result.columnValue<Long>(columnName, tableName)?.let { Date(it) }
+
+    override fun decodeValue(value: Date): Any? = value.time
+}

--- a/kuick-repositories-squash/src/jvmTest/kotlin/kuick/repositories/squash/BasicOpsSquashRepoTest.kt
+++ b/kuick-repositories-squash/src/jvmTest/kotlin/kuick/repositories/squash/BasicOpsSquashRepoTest.kt
@@ -5,6 +5,7 @@ import kuick.repositories.eq
 import kuick.repositories.gt
 import kuick.repositories.gte
 import kuick.repositories.within
+import java.util.*
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -20,8 +21,8 @@ class BasicOpsSquashRepoTest: AbstractITTest() {
                     val lastName: String,
                     val ageOfUser: Int,
                     val married: Boolean,
-                    val createdAt: Long,
-                    val updatedAt: Long? = null
+                    val createdAt: Date,
+                    val updatedAt: Date? = null
     )
 
 
@@ -77,7 +78,7 @@ class BasicOpsSquashRepoTest: AbstractITTest() {
         repo.insert(mike)
         assertEquals(mike, repo.findById(mike.userId))
 
-        val mike2 = mike.copy(updatedAt = System.currentTimeMillis())
+        val mike2 = mike.copy(updatedAt = Date())
         repo.update(mike2)
         assertEquals(mike2, repo.findById(mike.userId))
     }
@@ -90,6 +91,6 @@ class BasicOpsSquashRepoTest: AbstractITTest() {
                     fullName.substringAfter(' '),
                     age,
                     married,
-                    System.currentTimeMillis(),
+                    Date(),
                     updatedAt = null)
 }


### PR DESCRIPTION
Guardar las fechas como long sin formato dificulta bastante el trabajo en Metabase.

He creado una forma alternativa: los objetos de tipo 'date' se pasan a la zona horaria UTC y se guardan en la base de datos como timestamps.

a la hora de recuperdar los objetos 'date' de la base de datos, en la conversión se tiene en cuenta la difernecias de zonas horarias entre la maquina local y el valor UTC

Esto permite seguir teniendo fechas correctas sea cual sea la zona horaria de la máquina. Además, en metabase se pueden usar de forma fácil sus features relacionadas con fechas

![image](https://user-images.githubusercontent.com/4629402/55569932-ba614a00-5702-11e9-9c12-5e34996782cf.png)

![image](https://user-images.githubusercontent.com/4629402/55569963-c947fc80-5702-11e9-922a-9dee514212ce.png)

Entiendo que esta feature rompe compatibilidad con lo que tiene ahora mismo gokoan en producción, si quereis puedo hacer algo para que siga aceptando el formato antiguo, para no forzar la migración
