### PR TITLE
added UUID native serialization for modelrepositorysquash

### DIFF
--- a/kuick-repositories-squash/src/jvmMain/kotlin/kuick/repositories/squash/StandardSerializationStrategies.kt
+++ b/kuick-repositories-squash/src/jvmMain/kotlin/kuick/repositories/squash/StandardSerializationStrategies.kt
@@ -37,6 +37,7 @@ val intSerialization = SerializationStrategy({ integer(it.columnName) }, { it<In
 val longSerialization = SerializationStrategy({ long(it.columnName) }, { it<Long>() }, { it })
 val doubleSerialization = SerializationStrategy({ decimal(it.columnName, 5, 4) }, { it<BigDecimal>()?.toDouble() }, { it })
 val booleanSerialization = SerializationStrategy({ bool(it.columnName) }, { it<Boolean>() }, { value -> value })
+val uuidSerialization = SerializationStrategy({ uuid(it.columnName) }, { it<UUID>() }, { value -> value })
 
 val localDateSerialization = VarCharSerializationStrategy(
         LocalDate::class,
@@ -100,6 +101,7 @@ val defaultSerializationStrategies: SerializationStrategy = serializationStrateg
         localDateSerialization,
         localDateTimeSerialization,
         emailSerialization,
+        uuidSerialization,
         IdSerializationStrategy
 )
 

--- a/kuick-repositories-squash/src/jvmTest/kotlin/kuick/repositories/squash/BasicOpsSquashRepoTest.kt
+++ b/kuick-repositories-squash/src/jvmTest/kotlin/kuick/repositories/squash/BasicOpsSquashRepoTest.kt
@@ -17,6 +17,7 @@ class BasicOpsSquashRepoTest: AbstractITTest() {
     data class UserId(override val id: String): Id
 
     data class User(val userId: UserId,
+                    val uuid: UUID,
                     val firstName: String,
                     val lastName: String,
                     val ageOfUser: Int,
@@ -52,6 +53,7 @@ class BasicOpsSquashRepoTest: AbstractITTest() {
         assertEquals(2, repo.findBy(User::ageOfUser gt 12).size)
         assertEquals(3, repo.findBy(User::ageOfUser gte 12).size)
         assertEquals(2, repo.findBy(User::married eq true).size)
+        assertEquals(mike.uuid, repo.findBy(User::uuid eq mike.uuid).first().uuid)
 
         assertEquals(4,
                 repo.findBy(User::lastName within setOf("Ballesteros")).size,
@@ -98,6 +100,7 @@ class BasicOpsSquashRepoTest: AbstractITTest() {
 
     private fun user(id: String, fullName: String, age: Int, married: Boolean) =
             User(UserId(id),
+                    UUID.randomUUID(),
                     fullName.substringBefore(' '),
                     fullName.substringAfter(' '),
                     age,


### PR DESCRIPTION
esto permite poder usar UUID directamente (16 bytes) en vez de varchar(36 bytes)