### PR TITLE
Cache improvements

### DIFF
--- a/kuick-cache-db/src/jvmMain/kotlin/kuick/caching/db/DbCacheInvalidation.kt
+++ b/kuick-cache-db/src/jvmMain/kotlin/kuick/caching/db/DbCacheInvalidation.kt
@@ -78,7 +78,7 @@ class DbCacheInvalidation @PublishedApi internal constructor(val coroutineContex
     }
 }
 
-fun <T : Any> Cache<String, T>.invalidatedBy(dbCacheInvalidation: DbCacheInvalidation): Cache<String, T> {
+fun <T> Cache<String, T>.invalidatedBy(dbCacheInvalidation: DbCacheInvalidation): Cache<String, T> {
     val parent = this
     val cacheName = this.name
 
@@ -89,6 +89,8 @@ fun <T : Any> Cache<String, T>.invalidatedBy(dbCacheInvalidation: DbCacheInvalid
     return object : Cache<String, T> {
         override suspend fun get(key: String, builder: suspend (key: String) -> T): T = parent.get(key, builder)
         override suspend fun invalidate(key: String) = run { dbCacheInvalidation.invalidate(cacheName, key) }
+        override suspend fun invalidateAll() = run { dbCacheInvalidation.invalidateAll(cacheName) }
+
         override suspend fun close() {
             parent.close()
             @Suppress("BlockingMethodInNonBlockingContext")

--- a/kuick-cache-redis/src/jvmMain/kotlin/kuick/caching/redis/CacheWithRedisInvalidation.kt
+++ b/kuick-cache-redis/src/jvmMain/kotlin/kuick/caching/redis/CacheWithRedisInvalidation.kt
@@ -3,7 +3,7 @@ package kuick.caching.redis
 import kuick.caching.*
 import java.io.*
 
-class CacheWithRedisInvalidation<V : Any> @PublishedApi internal constructor(
+class CacheWithRedisInvalidation<V> @PublishedApi internal constructor(
         val parentCache: Cache<String, V>,
         val cacheName: String,
         val invalidationRedisClient: InvalidationRedisClient

--- a/kuick-cache-redis/src/jvmMain/kotlin/kuick/caching/redis/RedisCache.kt
+++ b/kuick-cache-redis/src/jvmMain/kotlin/kuick/caching/redis/RedisCache.kt
@@ -6,25 +6,27 @@ import kuick.client.redis.*
 import kuick.json.*
 import kotlin.reflect.*
 
-class RedisCache<V : Any> @PublishedApi internal constructor(
+class RedisCache @PublishedApi internal constructor(
         private val redis: RedisSuspendCommands<String, String>,
-        private val cacheName: String,
-        private val clazz: KClass<V>
-) : Cache<String, V> {
+        private val cacheName: String
+) : Cache<String, String> {
     override val name: String get() = cacheName
 
     companion object {
-        suspend inline operator fun <reified V : Any> invoke(cacheName: String, uri: RedisURI = RedisURI.create("redis://localhost/"), client: RedisClient = RedisClient.create()): RedisCache<V> {
-            return RedisCache(client.connectSuspend(uri).suspending(), cacheName, V::class)
+        suspend operator fun invoke(cacheName: String, uri: RedisURI = RedisURI.create("redis://localhost/"), client: RedisClient = RedisClient.create()): RedisCache {
+            return RedisCache(client.connectSuspend(uri).suspending(), cacheName)
         }
     }
 
-    override suspend fun get(key: String, builder: suspend (key: String) -> V): V {
-        val value = redis.hget(cacheName, key) ?: return builder(key).also { redis.hset(cacheName, key, Json.toJson(it)) }
-        return Json.fromJson(value, clazz)
+    override suspend fun get(key: String, builder: suspend (key: String) -> String): String {
+        return redis.hget(cacheName, key) ?: return builder(key).also { redis.hset(cacheName, key, it) }
     }
 
     override suspend fun invalidate(key: String) {
         redis.hdel(cacheName, key)
+    }
+
+    override suspend fun invalidateAll() {
+        redis.del(cacheName)
     }
 }

--- a/kuick-cache-redis/src/jvmTest/kotlin/kuick/caching/redis/RedisCacheTest.kt
+++ b/kuick-cache-redis/src/jvmTest/kotlin/kuick/caching/redis/RedisCacheTest.kt
@@ -25,13 +25,14 @@ class RedisCacheTest {
 
     @Test
     fun test() = runBlocking {
-        val cache = RedisCache<MyClass>("mycache", RedisURI.create("redis://${container.ipAddress}"))
+        val cache = RedisCache("mycache", RedisURI.create("redis://${container.ipAddress}")).typeWithJson<MyClass>()
         val instance = MyClass(10)
         val result1 = cache.get("test") { instance }
         val result2 = cache.get("test") { instance }
         assertEquals(10, result1.v)
         assertEquals(10, result2.v)
-        assertSame(result1, instance, "First call should return the same object")
+        //assertSame(result1, instance, "First call should return the same object")
+        assertNotSame(result1, instance, "First call does not return the same object since it uses typeWithJson")
         assertNotSame(result1, result2, "If deserialized, should be a different instance")
     }
 

--- a/kuick-core/src/commonMain/kotlin/kuick/caching/Cache.kt
+++ b/kuick-core/src/commonMain/kotlin/kuick/caching/Cache.kt
@@ -2,21 +2,18 @@ package kuick.caching
 
 import kuick.util.*
 
-interface Cache<K : Any, V : Any> : Invalidable<K>, AsyncCloseable, Named {
+interface Cache<K : Any, V> : Invalidable<K>, AsyncCloseable, Named {
     override val name get() = "UnnamedCache"
     suspend fun get(key: K, builder: suspend (key: K) -> V): V
     override suspend fun close() = Unit
 }
 
-fun <K : Any, V : Any> Cache<K, V>.interceptInvalidation(invalidation: (key: K) -> Unit): Cache<K, V> = object : Cache<K, V> by this {
+fun <K : Any, V> Cache<K, V>.interceptInvalidation(invalidation: (key: K) -> Unit): Cache<K, V> = object : Cache<K, V> by this {
     override suspend fun invalidate(key: K) {
         invalidation(key)
         return this@interceptInvalidation.invalidate(key)
     }
 }
-fun <K : Any, V : Any> Cache<K, V>.interceptGet(get: (key: K, value: V) -> V): Cache<K, V> = object : Cache<K, V> by this {
-    override suspend fun get(key: K, builder: suspend (key: K) -> V): V = this@interceptGet.get(key) { key ->
-        val value = builder(key)
-        get(key, value)
-    }
+fun <K : Any, V> Cache<K, V>.interceptGet(get: (key: K, value: V) -> V): Cache<K, V> = object : Cache<K, V> by this {
+    override suspend fun get(key: K, builder: suspend (key: K) -> V): V = this@interceptGet.get(key) { get(it, builder(it)) }
 }

--- a/kuick-core/src/commonMain/kotlin/kuick/caching/CacheTtl.kt
+++ b/kuick-core/src/commonMain/kotlin/kuick/caching/CacheTtl.kt
@@ -6,7 +6,7 @@ import kuick.time.Clock
 import kuick.time.SimpleClock
 import kuick.time.now
 
-class CacheTtl<K : Any, V : Any>(
+class CacheTtl<K : Any, V>(
         val parent: Cache<K, V>,
         val maxEntries: Int = CacheTtl.UNLIMITED,
         val maxMilliseconds: Int = CacheTtl.UNLIMITED,

--- a/kuick-core/src/commonMain/kotlin/kuick/caching/CacheWithBuilder.kt
+++ b/kuick-core/src/commonMain/kotlin/kuick/caching/CacheWithBuilder.kt
@@ -3,8 +3,8 @@ package kuick.caching
 import kuick.util.AsyncCloseable
 import kuick.util.Named
 
-class CacheWithBuilder<K : Any, V : Any>(val cache: Cache<K, V>, val builder: suspend (key: K) -> V) : Invalidable<K> by cache, AsyncCloseable by cache, Named by cache {
+class CacheWithBuilder<K : Any, V>(val cache: Cache<K, V>, val builder: suspend (key: K) -> V) : Invalidable<K> by cache, AsyncCloseable by cache, Named by cache {
     suspend fun get(key: K): V = cache.get(key) { builder(key) }
 }
 
-fun <K : Any, V : Any> Cache<K, V>.withBuilder(builder: suspend (key: K) -> V) = CacheWithBuilder(this, builder)
+fun <K : Any, V> Cache<K, V>.withBuilder(builder: suspend (key: K) -> V) = CacheWithBuilder(this, builder)

--- a/kuick-core/src/commonMain/kotlin/kuick/caching/InmemoryCache.kt
+++ b/kuick-core/src/commonMain/kotlin/kuick/caching/InmemoryCache.kt
@@ -5,7 +5,7 @@ import kuick.concurrent.*
 import kuick.util.*
 import kotlin.coroutines.*
 
-class InmemoryCache<K : Any, V : Any>(override val name: String = "InmemoryCache") : Cache<K, V> {
+class InmemoryCache<K : Any, V>(override val name: String = "InmemoryCache") : Cache<K, V> {
     private val lock = Lock()
     private val map = LinkedHashMap<K, Deferred<V>>()
 

--- a/kuick-core/src/commonMain/kotlin/kuick/caching/Invalidable.kt
+++ b/kuick-core/src/commonMain/kotlin/kuick/caching/Invalidable.kt
@@ -2,5 +2,6 @@ package kuick.caching
 
 interface Invalidable<K : Any> {
     suspend fun invalidate(key: K)
-    suspend fun invalidateAll(): Unit = TODO("Invalidable.invalidateAll not implemented")
+    suspend fun invalidateAll()
+    //suspend fun invalidateAll(): Unit = TODO("Invalidable.invalidateAll not implemented")
 }

--- a/kuick-core/src/jvmMain/kotlin/kuick/caching/CacheStringJson.kt
+++ b/kuick-core/src/jvmMain/kotlin/kuick/caching/CacheStringJson.kt
@@ -1,0 +1,25 @@
+package kuick.caching
+
+import kuick.json.Json
+import kuick.util.AsyncCloseable
+import kuick.util.Named
+import kotlin.reflect.KClass
+
+fun <T : Any> Cache<String, String>.typeWithJsonNullable(clazz: KClass<T>): Cache<String, T?> {
+    val parent = this
+    return object : Cache<String, T?>, Invalidable<String> by parent, AsyncCloseable by parent, Named by parent {
+        override suspend fun get(key: String, builder: suspend (key: String) -> T?): T? =
+            Json.fromJsonNullable(parent.get(key) { Json.toJson(builder(it)) }, clazz)
+    }
+}
+
+fun <T : Any> Cache<String, String>.typeWithJson(clazz: KClass<T>): Cache<String, T> {
+    val parent = this
+    return object : Cache<String, T>, Invalidable<String> by parent, AsyncCloseable by parent, Named by parent {
+        override suspend fun get(key: String, builder: suspend (key: String) -> T): T =
+            Json.fromJson(parent.get(key) { Json.toJson(builder(it)) }, clazz)
+    }
+}
+
+inline fun <reified T : Any> Cache<String, String>.typeWithJson(): Cache<String, T> = typeWithJson(T::class)
+inline fun <reified T : Any> Cache<String, String>.typeWithJsonNullable(): Cache<String, T?> = typeWithJsonNullable(T::class)

--- a/kuick-core/src/jvmMain/kotlin/kuick/caching/DiskCache.kt
+++ b/kuick-core/src/jvmMain/kotlin/kuick/caching/DiskCache.kt
@@ -2,31 +2,48 @@ package kuick.caching
 
 import kuick.concurrent.async.*
 import kuick.file.*
-import kuick.json.*
-import kuick.util.*
 import kuick.utils.*
 import java.io.*
-import kotlin.reflect.*
 
-class DiskCache<V : Any>(val clazz: KClass<V>, override val name: String, val cacheDir: File) : Cache<String, V> {
+class DiskCache(
+    override val name: String,
+    val cacheDir: File = File(System.getProperty("java.io.tmpdir"))
+) : Cache<String, String> {
+    init {
+        cacheDir.mkdirs()
+    }
+
     fun getFileForKey(key: String): File = File(cacheDir, "kuick-cache-$name-${key.toByteArray().sha1().hex}")
 
+    private val asyncGlobal = AsyncThread()
     private val asyncThread = NamedAsyncThreads()
 
-    override suspend fun get(key: String, builder: suspend (key: String) -> V): V = asyncThread(key) {
-        val file = getFileForKey(key)
-        //println("File: $file")
-        when {
-            file.exists() -> Json.fromJson(file.readTextSuspend(), clazz)
-            else -> builder(key).also { file.writeTextSuspend(Json.toJson(it)) }
+    override suspend fun get(key: String, builder: suspend (key: String) -> String): String = asyncThread(key) {
+        asyncGlobal {
+            val file = getFileForKey(key)
+            //println("File: $file")
+            when {
+                file.exists() -> file.readTextSuspend()
+                else -> builder(key).also { file.writeTextSuspend(it) }
+            }
         }
     }
 
     override suspend fun invalidate(key: String) = asyncThread(key) {
-        getFileForKey(key).deleteSuspend()
-        Unit
+        asyncGlobal {
+            getFileForKey(key).deleteSuspend()
+            Unit
+        }
+    }
+
+    override suspend fun invalidateAll() {
+        asyncGlobal {
+            val base = "kuick-cache-$name-"
+            for (file in cacheDir.listFilesSuspend()) {
+                if (file.startsWith(base)) {
+                    file.deleteSuspend()
+                }
+            }
+        }
     }
 }
-
-inline fun <reified T : Any> DiskCache(name: String, cacheDir: File = File(System.getProperty("java.io.tmpdir"))) =
-        DiskCache(T::class, name, cacheDir)

--- a/kuick-core/src/jvmMain/kotlin/kuick/caching/GoogleMemoryCache.kt
+++ b/kuick-core/src/jvmMain/kotlin/kuick/caching/GoogleMemoryCache.kt
@@ -9,11 +9,11 @@ import java.time.Duration
 import java.util.concurrent.TimeUnit
 import kotlin.coroutines.*
 
-class GoogleMemoryCache<K: Any, T:Any>(maxSize: Long, duration: Duration) : Cache<K, T> {
+class GoogleMemoryCache<K: Any, T>(maxSize: Long?, duration: Duration?) : Cache<K, T> {
     private val cache = CacheBuilder.newBuilder()
-            .maximumSize(maxSize)
-            .expireAfterWrite(duration.toMillis(), TimeUnit.MILLISECONDS)
-            .build<String, Deferred<T>>()
+        .apply { if (maxSize != null) maximumSize(maxSize) }
+        .apply { if (duration != null) expireAfterWrite(duration.toMillis(), TimeUnit.MILLISECONDS) }
+        .build<String, Deferred<T>>()
 
     @UseExperimental(KuickInternal::class)
     override suspend fun get(key: K, builder: suspend (key: K) -> T): T {

--- a/kuick-core/src/jvmMain/kotlin/kuick/file/FileExt.kt
+++ b/kuick-core/src/jvmMain/kotlin/kuick/file/FileExt.kt
@@ -24,3 +24,10 @@ suspend fun File.deleteSuspend() {
         file.delete()
     }
 }
+
+suspend fun File.listFilesSuspend(): Array<File> {
+    val file = this
+    return withContext(Dispatchers.IO) {
+        file.listFiles()
+    }
+}

--- a/kuick-core/src/jvmMain/kotlin/kuick/json/json.kt
+++ b/kuick-core/src/jvmMain/kotlin/kuick/json/json.kt
@@ -98,11 +98,20 @@ object Json {
             .registerTypeAdapter(LocalTime::class.java, LocalTimeAdapter())
             .create()
 
-    fun <T : Any> toJson(any: T): String = gson.toJson(any)
+    fun <T : Any> toJson(any: T?): String = if (any == null) "null" else gson.toJson(any)
 
     fun <T : Any> fromJson(@Language("JSON") json: String, clazz: Type): T {
         try {
             return gson.fromJson(json, clazz)
+        } catch (t: Throwable) {
+            println("ERROR parsing JSON: $clazz <-- $json")
+            throw t
+        }
+    }
+
+    fun <T : Any> fromJsonNullable(json: String, clazz: KClass<T>): T? {
+        try {
+            return gson.fromJson(json, clazz.java)
         } catch (t: Throwable) {
             println("ERROR parsing JSON: $clazz <-- $json")
             throw t

--- a/kuick-core/src/jvmTest/kotlin/kuick/caching/DiskCacheTest.kt
+++ b/kuick-core/src/jvmTest/kotlin/kuick/caching/DiskCacheTest.kt
@@ -11,11 +11,11 @@ class DiskCacheTest {
             val dir = File(System.getProperty("java.io.tmpdir"))
             val key = "test"
             val instance = Demo(10)
-            val cache = DiskCache(Demo::class, "demo", dir)
+            val cache = DiskCache("demo", dir).typeWithJsonNullable<Demo>()
             cache.invalidate(key)
             val test1 = cache.get(key) { instance }
             val test2 = cache.get(key) { instance }
-            assertSame(instance, test1)
+            assertNotSame(instance, test2, "typeWithJsonNullable serialize always")
             assertNotSame(test1, test2)
             assertEquals(test1, test2)
         }


### PR DESCRIPTION
* Allow Cache to have nullables values
* Separate Json serialization from Redis and Disk implementation
* Enable Json typing as a decorator with nullable support separately
* Allow GoogleMemoryCache to accept nullable arguments to skip some arguments