### PR TITLE
ORM where proposal

### DIFF
--- a/kuick-core/src/commonMain/kotlin/kotlin/internal/internal.kt
+++ b/kuick-core/src/commonMain/kotlin/kotlin/internal/internal.kt
@@ -5,5 +5,5 @@ package kotlin.internal
  */
 @Target(AnnotationTarget.TYPE)
 @Retention(AnnotationRetention.BINARY)
-internal annotation class Exact
+public annotation class Exact
 

--- a/kuick-core/src/jvmMain/kotlin/kuick/orm/OrmExt.kt
+++ b/kuick-core/src/jvmMain/kotlin/kuick/orm/OrmExt.kt
@@ -72,7 +72,39 @@ class TableDefinition<T : Any>(val clazz: KClass<T>, val serialization: TableSer
         }
         return constructor.call(*params.toTypedArray())
     }
+
+    fun buildDummy() = DummyInstanceBuilder.build(clazz)
 }
+
+// @TODO: Cache dummy instances
+object DummyInstanceBuilder {
+    fun <T : Any> build(clazz: KClass<T>): T = buildPrivate(clazz) as T
+
+    private fun buildPrivate(type: KType): Any? {
+        if (type.isMarkedNullable) return null
+        return buildPrivate(type.clazz)
+    }
+
+    private fun <T : Any> buildPrivate(clazz: KClass<T>): Any {
+        return when (clazz) {
+            String::class -> ""
+            Boolean::class -> false
+            Byte::class -> 0.toByte()
+            Short::class -> 0.toShort()
+            Int::class -> 0
+            Long::class -> 0L
+            Double::class -> 0.0
+            Float::class -> 0f
+            Map::class, MutableMap::class, LinkedHashMap::class -> LinkedHashMap<Any?, Any?>()
+            List::class, MutableList::class, ArrayList::class -> ArrayList<Any?>()
+            else -> {
+                val constructor = clazz.primaryConstructor ?: clazz.constructors.firstOrNull() ?: error("Class '$clazz' doesn't have constructors")
+                constructor.call(*constructor.valueParameters.map { buildPrivate(it.type) }.toTypedArray())
+            }
+        }
+    }
+}
+
 
 interface TableSerializationStrategy {
     fun resolve(column: ColumnDefinition<*>): TableSerializationStrategy? = this

--- a/kuick-db/src/jvmMain/kotlin/kuick/client/where/Where.kt
+++ b/kuick-db/src/jvmMain/kotlin/kuick/client/where/Where.kt
@@ -1,0 +1,75 @@
+package kuick.client.where
+
+import kuick.orm.*
+import kuick.repositories.*
+import kotlin.internal.*
+import kotlin.reflect.*
+import kotlin.reflect.full.*
+
+data class Where<T : Any>(
+    private val builder: ModelWhereBuilder<T>,
+    private val repo: ViewRepository<out Any, T>,
+    private val query: ModelQuery<T>? = null,
+    private val skip: Long = 0L,
+    private val limit: Int? = null,
+    private val orderBy: List<OrderBy<T>>? = null
+) {
+    fun skip(count: Long = 0L) = this.copy(skip = count)
+    fun limit(count: Int?) = this.copy(limit = count)
+
+    fun setWhere(block: ModelWhereBuilder<T>.(it: T) -> ModelQuery<T>): Where<T> {
+        return this.copy(query = block(builder, builder.instance))
+    }
+    fun where(block: ModelWhereBuilder<T>.(it: T) -> ModelQuery<T>): Where<T> {
+        val result = block(builder, builder.instance)
+        return when (this.query) {
+            null -> this.copy(query = result)
+            else -> this.copy(query = FilterExpAnd(this.query as ModelFilterExp<T>, result as ModelFilterExp<T>))
+        }
+    }
+
+    fun sortDesc(block: (it: T) -> KProperty0<*>): Where<T> =
+        copy(orderBy = (orderBy ?: listOf()) + OrderBy(builder.propsByName[block(builder.instance).name]!!, false))
+
+    fun sortAsc(block: (it: T) -> KProperty0<*>): Where<T> =
+        copy(orderBy = (orderBy ?: listOf()) + OrderBy(builder.propsByName[block(builder.instance).name]!!, true))
+
+    suspend fun count(skip: Long? = null, limit: Int? = null) = find(skip, limit).size
+
+    suspend fun find(skip: Long? = null, limit: Int? = null): List<T> {
+        return when (query) {
+            null -> repo.getAll()
+            else -> {
+                // @TODO: We should support ALWAYS or null here (1=1)
+                repo.findBy(AttributedModelQuery(query!!, skip ?: this.skip, this.limit ?: limit, orderBy?.let { OrderByMultiple(it) }))
+            }
+        }
+    }
+}
+
+open class ModelWhereBuilder<T : Any>(
+    val table: TableDefinition<T>
+) {
+    val instance by lazy { table.buildDummy() }
+    val propsByName by lazy { table.clazz.memberProperties.associateBy { it.name } }
+
+    private val <R : Any> KProperty0<@Exact R>.prop1 get() = (propsByName[this.name] as KProperty1<T, R?>?) ?: error("Can't find prop $name")
+
+    infix fun <R : Any> KProperty0<@Exact R>.within(value: Set<R>) = FieldWithin(prop1, value)
+    infix fun <R : Any> KProperty0<@Exact R>.eq(value: R?) = FieldEqs(prop1, value)
+    infix fun <R : Any> KProperty0<@Exact R>.ne(value: R?) = FieldNeq(prop1, value)
+    infix fun <R : Comparable<R>> KProperty0<@Exact R>.gt(value: R) = FieldGt(prop1, value)
+    infix fun <R : Comparable<R>> KProperty0<@Exact R>.ge(value: R) = FieldGte(prop1, value)
+    infix fun <R : Comparable<R>> KProperty0<@Exact R>.lt(value: R) = FieldGt(prop1, value)
+    infix fun <R : Comparable<R>> KProperty0<@Exact R>.le(value: R) = FieldGte(prop1, value)
+    infix fun KProperty0<String>.like(value: String) = FieldLike(prop1, value)
+
+    infix fun ModelFilterExp<T>.and(that: ModelFilterExp<T>) = FilterExpAnd(this, that)
+    infix fun ModelFilterExp<T>.or(that: ModelFilterExp<T>) = FilterExpOr(this, that)
+    fun ModelFilterExp<T>.not() = FilterExpNot(this)
+}
+
+fun <T : Any> ViewRepository<out Any, T>.where(table: TableDefinition<T>): Where<T> = Where(ModelWhereBuilder(table), this)
+fun <T : Any> ViewRepository<out Any, T>.where(table: TableDefinition<T>, block: ModelWhereBuilder<T>.(it: T) -> ModelQuery<T>): Where<T> = where(table).where(block)
+inline fun <reified T : Any> ViewRepository<out Any, T>.where(noinline block: ModelWhereBuilder<T>.(it: T) -> ModelQuery<T>): Where<T> = where(TableDefinition(T::class), block)
+inline val <reified T : Any> ViewRepository<out Any, T>.where: Where<T> get() = where(TableDefinition(T::class))

--- a/kuick-db/src/jvmTest/kotlin/kuick/where/WhereTest.kt
+++ b/kuick-db/src/jvmTest/kotlin/kuick/where/WhereTest.kt
@@ -1,0 +1,36 @@
+package kuick.where
+
+import kotlinx.coroutines.*
+import kuick.client.where.*
+import kuick.repositories.memory.*
+import java.util.concurrent.*
+import kotlin.test.*
+
+class WhereTest {
+    data class Question(val id: String, val category: String, val question: String, val date: Long)
+
+    // Equivalent to Ruby on Rails scopes
+    val Where<Question>.lastWeek get() = this.where { (it::date ge System.currentTimeMillis() - TimeUnit.DAYS.toMillis(7L)) }
+    fun Where<Question>.category(cat: String) = this.where { (it::category eq cat) }
+
+    @Test
+    fun test(): Unit = runBlocking {
+        val repo = ModelRepositoryMemory(Question::class, Question::id)
+        val cat1 = "cat1"
+        val cat2 = "cat2"
+
+        lateinit var q0: Question
+
+        repo.insert(Question("0", cat1, "hello", System.currentTimeMillis() - 1000).also { q0 = it })
+        repo.insert(Question("1", cat1, "hello", System.currentTimeMillis() - (TimeUnit.DAYS.toMillis(10L))))
+        repo.insert(Question("2", cat2, "world", System.currentTimeMillis() - 1000))
+
+        val cat1Rows = repo.where
+            .category(cat1)
+
+        assertEquals(2, cat1Rows.count())
+        assertEquals(1, cat1Rows.lastWeek.count())
+        assertEquals(listOf(q0), cat1Rows.lastWeek.find())
+    }
+
+}


### PR DESCRIPTION
This is a pending proposal I wanted to do and told to Mike. Based on the work I did for KMiniOrm here: https://korlibs.soywiz.com/kminiorm/

The idea of this is to continue using repositories but add a layer that allows to generate partial unexecuted queries that can be adjusted later. This allows to create domain-based extension properties or methods that deal with queries at the right abstraction level.
This is similar to Ruby on Rails scopes: https://www.rubyguides.com/2019/10/scopes-in-ruby-on-rails/ but as extension methods/properties.

Also in KMiniOrm I used a trick to avoid having to place the whole class name when accessing properties when querying. This allows to query with something like: `{ (it::a eq 10) and (it::b eq 20) }` so you don't have to put `{ (MyLongClassName::a eq 10) and (MyLongClassName::b eq 20) }` which greatly improves reading and it is less annoying to write.
